### PR TITLE
Change license in OPAM for GPL3 instead of MIT

### DIFF
--- a/wordpress.opam
+++ b/wordpress.opam
@@ -11,7 +11,7 @@ build: [
   [ "dune" "build" "@doc" "-p" name ] {with-doc}
 ]
 
-license: "MIT"
+license: "GPL3"
 tags: [ "shell" "bin" ]
 homepage: "https://github.com/xhtmlboi/wordpress"
 dev-repo: "git://github.com/xhtmlboi/wordpress.git"


### PR DESCRIPTION
The license in the repo is GPL3 but the license in OPAM field is MIT.